### PR TITLE
chore: ansibleの設定ファイルにてpythonのpathを定義

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,7 @@
 [defaults]
 duplicate_dict_key=error
 vault_password_file=./.vault_pass
-interpreter_python=/usr/bin/python3
+interpreter_python=auto_silent
 
 [inventory]
 any_unparsed_is_failed=True

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 duplicate_dict_key=error
 vault_password_file=./.vault_pass
+interpreter_python=/usr/bin/python3
 
 [inventory]
 any_unparsed_is_failed=True


### PR DESCRIPTION
## 変更内容

`ansible.cfg`でpythonのパスを定義

## 詳細

以下の警告を抑止するための設定
```
TASK [Gathering Facts] *********************************************************
[WARNING]: Platform linux on host zabbix-server01 is using the discovered
Python interpreter at /usr/bin/python3.9, but future installation of another
Python interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible-
core/2.18/reference_appendices/interpreter_discovery.html for more information.
ok: [zabbix-server01]
```